### PR TITLE
Improving DomainErrorExtensions

### DIFF
--- a/data/remote/src/main/kotlin/br/com/messore/tech/turtleracing/data/remote/extensions/DomainErrorExtensions.kt
+++ b/data/remote/src/main/kotlin/br/com/messore/tech/turtleracing/data/remote/extensions/DomainErrorExtensions.kt
@@ -2,17 +2,18 @@ package br.com.messore.tech.turtleracing.data.remote.extensions
 
 import br.com.messore.tech.turtleracing.data.remote.AuthenticationException
 import br.com.messore.tech.turtleracing.data.remote.UnexpectedException
+import java.net.HttpURLConnection
 import retrofit2.HttpException as RetrofitHttpException
 
-internal fun <T> Result<T>.getOrThrowDomainError(): T {
-    return getOrElse { throw it.toDomainError() }
+internal fun <T> Result<T>.getOrThrowDomainError(): T = getOrElse { throwable ->
+    throw throwable.toDomainError()
 }
 
 internal fun Throwable.toDomainError(): Throwable {
     return when (this) {
         is RetrofitHttpException -> {
-            when(code()) {
-                401 -> AuthenticationException
+            when (code()) {
+                HttpURLConnection.HTTP_UNAUTHORIZED -> AuthenticationException
                 else -> UnexpectedException(message())
             }
         }


### PR DESCRIPTION
- explicitly lambda argument and returning on signature method
- using Http constant to avoid magic numbers